### PR TITLE
Requirements.txt incorrectly referenced in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY custom_connector_queryfilter ${LAMBDA_TASK_ROOT}
 # Install the function's dependencies using file requirements.txt
 # from your project folder.
 COPY requirements.txt  .
-RUN  pip3 install -r ../requirements.txt --target "${LAMBDA_TASK_ROOT}"
+RUN  pip3 install -r ./requirements.txt --target "${LAMBDA_TASK_ROOT}"
 
 # Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
 CMD [ "custom_connector_example.handlers.lambda_handler.salesforce_lambda_handler" ]


### PR DESCRIPTION
# Issue
I get the following when running `docker build .` on this project:

```
$ docker build .
[+] Building 2.8s (10/10) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                  0.1s
 => => transferring dockerfile: 635B                                                                                                                                  0.0s
 => [internal] load .dockerignore                                                                                                                                     0.0s
 => => transferring context: 2B                                                                                                                                       0.0s
 => [internal] load metadata for public.ecr.aws/lambda/python:3.8                                                                                                     0.9s
 => [1/6] FROM public.ecr.aws/lambda/python:3.8@sha256:513942d4794d51e28b23d4077aef38ae3bcb7d67c62396190e17b4eb0edeb8f1                                               0.0s
 => [internal] load build context                                                                                                                                     0.2s
 => => transferring context: 413.48kB                                                                                                                                 0.2s
 => CACHED [2/6] COPY custom_connector_example /var/task                                                                                                              0.0s
 => CACHED [3/6] COPY custom_connector_sdk /var/task                                                                                                                  0.0s
 => CACHED [4/6] COPY custom_connector_queryfilter /var/task                                                                                                          0.0s
 => CACHED [5/6] COPY requirements.txt  .                                                                                                                             0.0s
 => ERROR [6/6] RUN  pip3 install -r ../requirements.txt --target "/var/task"                                                                                         1.6s
------
 > [6/6] RUN  pip3 install -r ../requirements.txt --target "/var/task":
#10 1.233 ERROR: Could not open requirements file: [Errno 2] No such file or directory: '../requirements.txt'
#10 1.480 WARNING: You are using pip version 21.1.1; however, version 22.0.3 is available.
#10 1.480 You should consider upgrading via the '/var/lang/bin/python3.8 -m pip install --upgrade pip' command.
------
executor failed running [/bin/sh -c pip3 install -r ../requirements.txt --target "${LAMBDA_TASK_ROOT}"]: exit code: 1
```

# Description of changes
The `requirements.txt` and `Dockerfile` are at both contained within the same folder. Additionally, once the `COPY` line is run, its copied to the main directory within the docker image.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
