### PR TITLE
default data_type_label to None, will get data_type.name

### DIFF
--- a/custom_connector_sdk/connector/fields.py
+++ b/custom_connector_sdk/connector/fields.py
@@ -237,7 +237,7 @@ class FieldDefinition:
     def __init__(self,
                  field_name: str,
                  data_type: FieldDataType,
-                 data_type_label: str,
+                 data_type_label: str = None,
                  label: str = None,
                  description: str = None,
                  is_primary_key: bool = None,


### PR DESCRIPTION
Issue #8 

Description of changes:
Default data_type_label to None.  This will cause it to be data_type.name if not specified, as the code already does that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
