### PR TITLE
Adding hasDestinationSupport bool in listConnectorEntities API

### DIFF
--- a/custom_connector_sdk/connector/context.py
+++ b/custom_connector_sdk/connector/context.py
@@ -5,6 +5,7 @@ from custom_connector_sdk.connector.auth import Credentials
 
 ENTITY_IDENTIFIER = 'entityIdentifier'
 HAS_NESTED_ENTITIES = 'hasNestedEntities'
+HAS_DESTINATION_SUPPORT = 'hasDestinationSupport'
 LABEL = 'label'
 DESCRIPTION = 'description'
 ENTITY = 'entity'
@@ -20,6 +21,7 @@ class Entity:
     def __init__(self,
                  entity_identifier: str,
                  has_nested_entities: bool,
+                 has_detination_support: bool,
                  label: str = None,
                  description: str = None):
         # Unique identifier for the entity. Can be entityId, entityName, entityPath+name, entityUrl, etc.
@@ -27,6 +29,9 @@ class Entity:
 
         # Specifies whether the connector entity is a parent or a category and has more entities nested underneath it.
         self.has_nested_entities = has_nested_entities
+        
+        # Specifies if entity is supported as a destination while creating flow
+        self.has_destination_support = has_destination_support
 
         # Label of the entity.
         self.label = label
@@ -37,6 +42,7 @@ class Entity:
     def to_dict(self):
         return {ENTITY_IDENTIFIER: self.entity_identifier,
                 HAS_NESTED_ENTITIES: self.has_nested_entities,
+                HAS_DESTINATION_SUPPORT: self.has_destination_support,
                 LABEL: self.label,
                 DESCRIPTION: self.description}
 
@@ -50,6 +56,7 @@ class Entity:
 
         entity_identifier = entity.get(ENTITY_IDENTIFIER)
         has_nested_entities = entity.get(HAS_NESTED_ENTITIES)
+        has_destination_support = entity.get(HAS_DESTINATION_SUPPORT)
         label = entity.get(LABEL)
         description = entity.get(DESCRIPTION)
 

--- a/custom_connector_sdk/connector/context.py
+++ b/custom_connector_sdk/connector/context.py
@@ -21,7 +21,7 @@ class Entity:
     def __init__(self,
                  entity_identifier: str,
                  has_nested_entities: bool,
-                 has_detination_support: bool,
+                 has_destination_support: bool,
                  label: str = None,
                  description: str = None):
         # Unique identifier for the entity. Can be entityId, entityName, entityPath+name, entityUrl, etc.
@@ -60,7 +60,7 @@ class Entity:
         label = entity.get(LABEL)
         description = entity.get(DESCRIPTION)
 
-        return cls(entity_identifier, has_nested_entities, label, description)
+        return cls(entity_identifier, has_nested_entities, has_destination_support, label, description)
 
 class EntityDefinition:
     """Data model of the Entity."""


### PR DESCRIPTION
Adding one boolean in listConnectorEntities API as requested by persistent.

Testing :

Done backward compatible testing,
Different values of this bool from server , with/without metadata cache.
Issues
https://i.amazon.com/EC2ISV-1197


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
